### PR TITLE
Update bower.json to master branch release of paper-input

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
     "iron-image": "^2.2.0",
     "paper-dialog": "^2.1.1",
     "paper-dropdown-menu": "https://github.com/StetSolutions/paper-dropdown-menu.git#feature/expose-ignore-select",
-    "paper-input": "c416ed910",
+    "paper-input": "^2.2.3",
     "paper-password-input": "^2.2.0",
     "paper-spinner": "^2.1.0",
     "paper-tabs": "^2.0.0",
@@ -37,8 +37,7 @@
     "web-animations-js": "^2.3.1"
   },
   "resolutions": {
-    "polymer": "^2.0.0",
-    "paper-input": "c416ed910"
+    "polymer": "^2.0.0"
   },
   "devDependencies": {
     "web-component-tester": "Polymer/web-component-tester#^6.0.0"

--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
     "iron-image": "^2.2.0",
     "paper-dialog": "^2.1.1",
     "paper-dropdown-menu": "https://github.com/StetSolutions/paper-dropdown-menu.git#feature/expose-ignore-select",
-    "paper-input": "08d7513da2",
+    "paper-input": "c416ed910",
     "paper-password-input": "^2.2.0",
     "paper-spinner": "^2.1.0",
     "paper-tabs": "^2.0.0",
@@ -38,7 +38,7 @@
   },
   "resolutions": {
     "polymer": "^2.0.0",
-    "paper-input": "08d7513da2"
+    "paper-input": "c416ed910"
   },
   "devDependencies": {
     "web-component-tester": "Polymer/web-component-tester#^6.0.0"


### PR DESCRIPTION
tl;dr: We will still need to revisit this later.

Please note, running the `bower install --save PolymerElements/paper-input` command still does not pull the most recent version of the master branch. I have updated the commit code to reflect the master branch where the issue was merged. I believe they need to add a tag for bower to be able to update with the bower install command